### PR TITLE
Rebirth slippage_tolerance params

### DIFF
--- a/contracts/dezswap_factory/src/contract.rs
+++ b/contracts/dezswap_factory/src/contract.rs
@@ -310,7 +310,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> StdResult<Response> {
                 assets,
                 receiver: Some(tmp_pair_info.sender.to_string()),
                 deadline: None,
-                min_assets: None,
+                slippage_tolerance: None,
             })?,
             funds,
         }));

--- a/contracts/dezswap_factory/src/contract.rs
+++ b/contracts/dezswap_factory/src/contract.rs
@@ -310,6 +310,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> StdResult<Response> {
                 assets,
                 receiver: Some(tmp_pair_info.sender.to_string()),
                 deadline: None,
+                min_assets: None,
             })?,
             funds,
         }));

--- a/contracts/dezswap_factory/src/testing.rs
+++ b/contracts/dezswap_factory/src/testing.rs
@@ -617,7 +617,7 @@ fn reply_create_pair_with_provide() {
                     assets,
                     receiver: Some("addr0000".to_string()),
                     deadline: None,
-                    min_assets: None,
+                    slippage_tolerance: None,
                 })
                 .unwrap(),
                 funds: coins(100u128, "axpla".to_string()),

--- a/contracts/dezswap_factory/src/testing.rs
+++ b/contracts/dezswap_factory/src/testing.rs
@@ -616,7 +616,8 @@ fn reply_create_pair_with_provide() {
                 msg: to_binary(&PairExecuteMsg::ProvideLiquidity {
                     assets,
                     receiver: Some("addr0000".to_string()),
-                    deadline: None
+                    deadline: None,
+                    min_assets: None,
                 })
                 .unwrap(),
                 funds: coins(100u128, "axpla".to_string()),

--- a/contracts/dezswap_pair/src/contract.rs
+++ b/contracts/dezswap_pair/src/contract.rs
@@ -376,7 +376,7 @@ pub fn provide_liquidity(
         None => {
             let default_mint_assets = assets.clone().map(|unit_asset| -> Asset {
                 let mut new_unit_asset = unit_asset.clone();
-                new_unit_asset.amount = new_unit_asset
+                new_unit_asset.amount = unit_asset
                     .amount
                     .checked_multiply_ratio(995u128, 1000u128)
                     .unwrap();

--- a/contracts/dezswap_pair/src/error.rs
+++ b/contracts/dezswap_pair/src/error.rs
@@ -35,4 +35,7 @@ pub enum ContractError {
         min_lp_token: String,
         given_lp: String,
     },
+
+    #[error("Max slippage assertion")]
+    MaxSlippageAssertion {},
 }

--- a/contracts/dezswap_pair/src/testing.rs
+++ b/contracts/dezswap_pair/src/testing.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use crate::contract::{
     assert_deadline, assert_max_spread, assert_minimum_assets, execute, instantiate,
     query_pair_info, query_pool, query_reverse_simulation, query_simulation, reply,
@@ -165,7 +167,7 @@ fn provide_liquidity() {
         ],
         receiver: None,
         deadline: None,
-        min_assets: None,
+        slippage_tolerance: None,
     };
     let env = mock_env();
     let info = mock_info(
@@ -205,9 +207,9 @@ fn provide_liquidity() {
                 amount: Uint128::from(10000u128),
             },
         ],
-        min_assets: None,
         receiver: None,
         deadline: None,
+        slippage_tolerance: None,
     };
 
     let env = mock_env();
@@ -218,6 +220,7 @@ fn provide_liquidity() {
             amount: Uint128::from(10000u128),
         }],
     );
+
     let res = execute(deps.as_mut(), env, info, msg).unwrap();
     let liquidity_to_contract_msg = res.messages.get(0).expect("no message");
     let transfer_from_msg = res.messages.get(1).expect("no message");
@@ -300,22 +303,9 @@ fn provide_liquidity() {
                 amount: Uint128::from(200u128),
             },
         ],
-        min_assets: Some([
-            Asset {
-                info: AssetInfo::Token {
-                    contract_addr: "asset0000".to_string(),
-                },
-                amount: Uint128::from(95u128),
-            },
-            Asset {
-                info: AssetInfo::NativeToken {
-                    denom: "uusd".to_string(),
-                },
-                amount: Uint128::from(101u128),
-            },
-        ]),
         receiver: Some("staking0000".to_string()), // try changing receiver
         deadline: None,
+        slippage_tolerance: Some(Decimal::from_str("0.005").unwrap()),
     };
 
     let env = mock_env();
@@ -329,8 +319,8 @@ fn provide_liquidity() {
 
     let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
     match res {
-        ContractError::MinAmountAssertion { .. } => (),
-        _ => panic!("MinAmountAssertion should be raised"),
+        ContractError::MaxSlippageAssertion { .. } => (),
+        _ => panic!("MaxSlippageAssertion should be raised"),
     }
 
     deps.querier.with_balance(&[(
@@ -370,22 +360,9 @@ fn provide_liquidity() {
                 amount: Uint128::from(101u128),
             },
         ],
-        min_assets: Some([
-            Asset {
-                info: AssetInfo::Token {
-                    contract_addr: "asset0000".to_string(),
-                },
-                amount: Uint128::from(99u128),
-            },
-            Asset {
-                info: AssetInfo::NativeToken {
-                    denom: "uusd".to_string(),
-                },
-                amount: Uint128::from(99u128),
-            },
-        ]),
         receiver: Some("staking0000".to_string()), // try changing receiver
         deadline: None,
+        slippage_tolerance: Some(Decimal::from_str("0.05").unwrap()),
     };
 
     let env = mock_env();
@@ -451,9 +428,9 @@ fn provide_liquidity() {
                 amount: Uint128::from(50u128),
             },
         ],
-        min_assets: None,
         receiver: None,
         deadline: None,
+        slippage_tolerance: Some(Decimal::from_str("0.005").unwrap()),
     };
 
     let env = mock_env();
@@ -509,22 +486,9 @@ fn provide_liquidity() {
                 amount: Uint128::from(98u128),
             },
         ],
-        min_assets: Some([
-            Asset {
-                info: AssetInfo::Token {
-                    contract_addr: "asset0000".to_string(),
-                },
-                amount: Uint128::from(98u128),
-            },
-            Asset {
-                info: AssetInfo::NativeToken {
-                    denom: "uusd".to_string(),
-                },
-                amount: Uint128::from(98u128),
-            },
-        ]),
         receiver: None,
         deadline: None,
+        slippage_tolerance: Some(Decimal::from_str("0.05").unwrap()),
     };
 
     let env = mock_env();

--- a/contracts/dezswap_pair/src/testing.rs
+++ b/contracts/dezswap_pair/src/testing.rs
@@ -165,6 +165,7 @@ fn provide_liquidity() {
         ],
         receiver: None,
         deadline: None,
+        min_assets: None,
     };
     let env = mock_env();
     let info = mock_info(

--- a/contracts/dezswap_router/src/contract.rs
+++ b/contracts/dezswap_router/src/contract.rs
@@ -203,9 +203,7 @@ fn assert_minimum_receive(
     let swap_amount = receiver_balance.checked_sub(prev_balance)?;
 
     if swap_amount < minium_receive {
-        return Err(StdError::generic_err(format!(
-            "assertion failed; minimum receive amount: {minium_receive}, swap amount: {swap_amount}"
-        )));
+        return Err(StdError::generic_err(format!("assertion failed; minimum receive amount: {minium_receive}, swap amount: {swap_amount}")));
     }
 
     Ok(Response::default())

--- a/packages/dezswap/src/mock_querier.rs
+++ b/packages/dezswap/src/mock_querier.rs
@@ -194,9 +194,7 @@ impl WasmMockQuerier {
                                     Some(balances) => balances,
                                     None => {
                                         return SystemResult::Err(SystemError::InvalidRequest {
-                                            error: format!(
-                                                "No balance info exists for the contract {contract_addr}"
-                                            ),
+                                            error: format!("No balance info exists for the contract {contract_addr}"),
                                             request: msg.as_slice().into(),
                                         })
                                     }
@@ -224,9 +222,7 @@ impl WasmMockQuerier {
                                     Some(balances) => balances,
                                     None => {
                                         return SystemResult::Err(SystemError::InvalidRequest {
-                                            error: format!(
-                                                "No balance info exists for the contract {contract_addr}"
-                                            ),
+                                            error: format!("No balance info exists for the contract {contract_addr}"),
                                             request: msg.as_slice().into(),
                                         })
                                     }

--- a/packages/dezswap/src/pair.rs
+++ b/packages/dezswap/src/pair.rs
@@ -22,9 +22,9 @@ pub enum ExecuteMsg {
     /// ProvideLiquidity a user provides pool liquidity
     ProvideLiquidity {
         assets: [Asset; 2],
-        min_assets: Option<[Asset; 2]>,
         receiver: Option<String>,
         deadline: Option<u64>,
+        slippage_tolerance: Option<Decimal>,
     },
     /// Swap an offer asset to the other
     Swap {

--- a/packages/dezswap/src/pair.rs
+++ b/packages/dezswap/src/pair.rs
@@ -22,6 +22,7 @@ pub enum ExecuteMsg {
     /// ProvideLiquidity a user provides pool liquidity
     ProvideLiquidity {
         assets: [Asset; 2],
+        min_assets: Option<[Asset; 2]>,
         receiver: Option<String>,
         deadline: Option<u64>,
     },


### PR DESCRIPTION
## Summary of changes

- **`slippage_tolerance` parameter has been rebirthed** in `providing liquidity` msg
- As the type is `Option<Decimal>`, it doen't occur any break.
- Need slippage tolerance option in the frontend. And `min_asset = asset * (1 - slippage_tolearnce)` should be applied

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [x] Wrote tests
- [ ] Added a relevant changelog entry to CHANGELOG.md

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
