### PR TITLE
refactor: fix native token decimals xerc20 type compatibility

### DIFF
--- a/contracts/dezswap_factory/src/state.rs
+++ b/contracts/dezswap_factory/src/state.rs
@@ -122,4 +122,20 @@ mod allow_native_token {
             7u8
         );
     }
+
+    #[test]
+    fn denom_low_case() {
+        let denom: String = "xerc20:B99a63f7e1BD195f65e2EBFcFC393897D73F24c9"
+            .to_ascii_lowercase()
+            .replace(":0x", ":");
+        assert_eq!(denom, "xerc20:b99a63f7e1bd195f65e2ebfcfc393897d73f24c9");
+
+        let denom: String = "xerc20:0xB99a63f7e1BD195f65e2EBFcFC393897D73F24c9"
+            .to_ascii_lowercase()
+            .replace(":0x", ":");
+        assert_eq!(denom, "xerc20:b99a63f7e1bd195f65e2ebfcfc393897d73f24c9");
+
+        let denom: String = "axpla".to_ascii_lowercase().replace(":0x", ":");
+        assert_eq!(denom, "axpla");
+    }
 }

--- a/contracts/dezswap_factory/src/testing.rs
+++ b/contracts/dezswap_factory/src/testing.rs
@@ -718,7 +718,7 @@ fn failed_add_allow_native_token_with_zero_factory_balance() {
     assert_eq!(
         execute(deps.as_mut(), mock_env(), info, msg),
         Err(StdError::generic_err(
-            "a balance greater than zero is required by the factory for verification",
+            "supply greater than zero is required by the factory for verification",
         ))
     );
 }


### PR DESCRIPTION
## Summary of changes

The network's xerc20 supports both xerc20:0x<contract address> and xerc20:<contract address>, regardless of case. However, there was an issue where only the denom initially registered in the contract could be used, and we improve this.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Added a relevant changelog entry to CHANGELOG.md

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
